### PR TITLE
Feature/in out folder

### DIFF
--- a/application/controllers/cron/Process.php
+++ b/application/controllers/cron/Process.php
@@ -141,7 +141,7 @@ class Process extends CI_Controller
                         $this->paragraph_tokenize($dir);
                     }
                     if (!$treebank->is_word_tokenised) {
-                        $this->paragraph_tokenize($dir);
+                        $this->word_tokenize($dir);
                     }
 
                     // currently these text files are converted in-place to Lassy XML files

--- a/application/language/english/common_lang.php
+++ b/application/language/english/common_lang.php
@@ -21,6 +21,7 @@ $lang['uploaded_at'] = 'Uploaded at';
 $lang['processed_at'] = 'Processed at';
 $lang['upload_success'] = 'Successfully uploaded your treebank.<br><br>Your treebank will now be processed. You will receive a mail when the processing has finished. Processing can take up to a day, depending on the size of your corpus.';
 $lang['treebank_processed'] = 'Successfully processed your treebank';
+$lang['treebank_failure'] = ' Problem processing your treebank, consult the log';
 $lang['treebank_reset'] = 'Successfully reset your treebank';
 $lang['treebank_deleted'] = 'Successfully deleted your treebank';
 $lang['treebank_access_modified'] = 'Successfully changed access rights of your treebank';

--- a/application/models/Component_model.php
+++ b/application/models/Component_model.php
@@ -116,4 +116,14 @@ class Component_model extends CI_Model
     {
         $this->db->delete('components', array('treebank_id' => $treebank_id));
     }
+
+    /**
+     * Deletes a Component.
+     *
+     * @param int $component_id the ID of the Component
+     */
+    public function delete_component($component_id)
+    {
+        $this->db->delete('components', array('id' => $component_id));
+    }
 }

--- a/application/models/Treebank_model.php
+++ b/application/models/Treebank_model.php
@@ -173,13 +173,13 @@ class Treebank_model extends CI_Model
         if ($dir == null) {
             $name = strtoupper(substr($title, 0, 252).'_ID');
         } else {
-            $slug = substr(str_replace(array('\\', '/'), '_', $dir), 0, 100);
+            $slug = substr(preg_replace('/[\\/ ]+/', '_', $dir), 0, 100);
             // make sure the database name does not exceed the filename limit of 255 characters
             $name = strtoupper(substr($title, 0, 251 - strlen($slug)).'_ID_'.$slug);
         }
 
         // only allow really boring ASCII characters
-        $name = strtoupper(preg_replace('/[^a-zA-Z0-9_]/', '_', $name));
+        $name = strtoupper(preg_replace('/[^a-zA-Z0-9_]+/', '_', $name));
 
         if ($existing_names === null) {
             return $name;

--- a/application/views/treebank_list.php
+++ b/application/views/treebank_list.php
@@ -5,6 +5,11 @@
 		<?=$this->session->flashdata('message'); ?>
 	</div>
 <?php } ?>
+<?php if ($this->session->flashdata('error')) { ?>
+	<div class="error">
+		<?=$this->session->flashdata('error'); ?>
+	</div>
+<?php } ?>
 
 <?php if ($treebanks) { ?>
 <table class="pure-table">


### PR DESCRIPTION
This changes the parsing to extract everything to an "in" folder and then send the output of corpus2alpino and the merging to an "out" folder. This way archives containing existing xml files can be parsed e.g. a TEI called `tei.xml` would have a folder `tei.xml` in the output, contain `1.xml`, `2.xml`, ... `n.xml` for every parsed sentence. This also fixes a whole bunch of other bugs with processing.

I've also updated the naming conventions, the example above would get a sentence ID of tei.xml:1 prefixed with the component. Components are titled using slashes (as their directory names).

In the future these changes will also make it feasible to automatically merge chat and pre-annotated lassy files (https://github.com/UUDigitalHumanitieslab/GrETEL-upload/issues/18, https://github.com/UUDigitalHumanitieslab/corpus2alpino/issues/7).